### PR TITLE
Fix SQL injection vulnerability in users controller

### DIFF
--- a/canaries/ruby/railsgoat/app/controllers/users_controller.rb
+++ b/canaries/ruby/railsgoat/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
   def update
     message = false
 
-    user = User.where("id = '#{params[:user][:id]}'")[0]
+    user = User.where(id: params[:user][:id]).first
 
     if user
       user.update(user_params_without_password)


### PR DESCRIPTION
Replace string interpolation in WHERE clause with parameterized query to prevent SQL injection attacks in the user update method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)